### PR TITLE
update workflow targets

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -34,7 +34,7 @@ jobs:
           - molecule_distro: 'debian:10'
             experimental: false
     env:
-      ANSIBLE_CALLBACK_ENABLED: profile_tasks
+      ANSIBLE_CALLBACKS_ENABLED: profile_tasks
       MOLECULE_NO_LOG: "false"
 
     steps:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,7 +16,8 @@ jobs:
       max-parallel: 4
       matrix:
         molecule_distro:
-          - 'centos:8'
+          - 'redhat/ubi8'
+          - 'rockylinux:8'
           - 'centos:7'
           - 'ubuntu:20.04'
           - 'ubuntu:18.04'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,17 +11,28 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        molecule_distro:
-          - 'redhat/ubi8'
-          - 'rockylinux:8'
-          - 'centos:7'
-          - 'ubuntu:20.04'
-          - 'ubuntu:18.04'
-          - 'debian:10'
+        include:
+          - molecule_distro: 'redhat/ubi8'
+            experimental: false
+          - molecule_distro: 'rockylinux:8'
+            experimental: false
+          - molecule_distro: 'centos:7'
+            experimental: false
+          - molecule_distro: 'ubuntu:22.04'
+            experimental: true
+          - molecule_distro: 'ubuntu:20.04'
+            experimental: false
+          - molecule_distro: 'ubuntu:18.04'
+            experimental: false
+          - molecule_distro: 'ubuntu:16.04'
+            experimental: false
+          - molecule_distro: 'debian:10'
+            experimental: false
     env:
       ANSIBLE_CALLBACK_ENABLED: profile_tasks
       MOLECULE_NO_LOG: "false"


### PR DESCRIPTION
* add redhat/ubi8 and rockylinux:8 as docker images to replace centos:8 which is not available anymore
* add upcoming ubuntu 22.04 as experimental (even if failing, it does not impact the final green/red check). it seems molecule misses the right creation playbook but 22.04 docker is available per https://hub.docker.com/_/ubuntu/
* fix typo in callbacks_enabled