### PR TITLE
Update to latest 0.6.7-5

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,19 +17,17 @@ jobs:
       max-parallel: 4
       matrix:
         include:
+          - molecule_distro: 'rockylinux:9'
+            experimental: false
           - molecule_distro: 'redhat/ubi8'
             experimental: false
           - molecule_distro: 'rockylinux:8'
-            experimental: false
-          - molecule_distro: 'centos:7'
             experimental: false
           - molecule_distro: 'ubuntu:22.04'
             experimental: true
           - molecule_distro: 'ubuntu:20.04'
             experimental: false
-          - molecule_distro: 'ubuntu:18.04'
-            experimental: false
-          - molecule_distro: 'ubuntu:16.04'
+          - molecule_distro: 'debian:11'
             experimental: false
           - molecule_distro: 'debian:10'
             experimental: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,8 @@ velociraptor_server: false
 velociraptor_version: "v0.6.5"
 # only if patch version and difference in versions used in download url
 # leave undefined or empty else
-velociraptor_version_topdir: v0.6.5-0
-velociraptor_version_patch: v0.6.5-2
+velociraptor_version_topdir: v0.6.5-5
+velociraptor_version_patch: v0.6.5-5
 velociraptor_admin_user: admin
 velociraptor_admin_password: "{{ vault_velociraptor_admin_password }}"
 velociraptor_host: "{{ ansible_default_ipv4.address }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,11 @@
 
 velociraptor_client: false
 velociraptor_server: false
-velociraptor_version: "v0.6.5"
+velociraptor_version: "v0.6.7"
 # only if patch version and difference in versions used in download url
 # leave undefined or empty else
-velociraptor_version_topdir: v0.6.5-5
-velociraptor_version_patch: v0.6.5-5
+velociraptor_version_topdir: v0.6.7-5
+velociraptor_version_patch: v0.6.7-5
 velociraptor_admin_user: admin
 velociraptor_admin_password: "{{ vault_velociraptor_admin_password }}"
 velociraptor_host: "{{ ansible_default_ipv4.address }}"


### PR DESCRIPTION
* bump version
* update ci for newer distributions and remove older ones which are failing (`/opt/velociraptor/velociraptor: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /opt/velociraptor/velociraptor)`)