### PR TITLE
fix: no become on orchestrator

### DIFF
--- a/tasks/install/install_server.yml
+++ b/tasks/install/install_server.yml
@@ -70,6 +70,7 @@
     dest: "{{ role_path }}/files/client.config.yaml"
     mode: '0664'
   delegate_to: localhost
+  become: false
 
 - name: "Install Server | Update Apt Cache"
   ansible.builtin.apt:


### PR DESCRIPTION
In one of my environment, role was failing because asking sudo prompt on the orchestrator.
There is no reason for it so added explicit become=false